### PR TITLE
Fixed jQuery cdn link

### DIFF
--- a/examples.html
+++ b/examples.html
@@ -23,7 +23,7 @@
         <div class="github-mentions">
             You can find @AnSavvides on GitHub!
         </div>
-        <script src="//ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js"></script>
+        <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js"></script>
         <script src="jquery.linky.js"></script>
         <script>
             $(".url").linky();


### PR DESCRIPTION
example.html was not working locally. The link to jQuery needed "http:" 